### PR TITLE
Removing C5 references to allow compilation on NETStandard1.0

### DIFF
--- a/S2Geometry/DataStructures/NullObject.cs
+++ b/S2Geometry/DataStructures/NullObject.cs
@@ -5,16 +5,16 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Google.Common.Geometry.DataStructures
+namespace Google.Common.Geometry
 {
-    public struct NullObject<T>
+    internal struct NullObject<T> : IEquatable<T>
     {
-        [DefaultValue(true)]
-        private bool isnull;// default property initializers are not supported for structs
+        [DefaultValue(false)]
+        private bool isNotNull;// default property initializers are not supported for structs
 
         private NullObject(T item, bool isnull) : this()
         {
-            this.isnull = isnull;
+            this.isNotNull = isNotNull;
             this.Item = item;
         }
 
@@ -31,7 +31,12 @@ namespace Google.Common.Geometry.DataStructures
 
         public bool IsNull()
         {
-            return this.isnull;
+            return !this.isNotNull;
+        }
+
+        public bool IsNotNull()
+        {
+            return this.isNotNull;
         }
 
         public static implicit operator T(NullObject<T> nullObject)
@@ -49,12 +54,28 @@ namespace Google.Common.Geometry.DataStructures
             return (Item != null) ? Item.ToString() : "NULL";
         }
 
-        public override bool Equals(object obj)
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                if (this.IsNull())
+                return 0;
+
+                var result = Item.GetHashCode();
+
+                if (result >= 0)
+                    result++;
+            
+                return result;
+            }
+        }
+
+        public bool Equals(T obj)
         {
             if (obj == null)
                 return this.IsNull();
 
-            if (!(obj is NullObject<T>))
+            if (!(obj is T))
                 return false;
 
             var no = (NullObject<T>)obj;
@@ -66,19 +87,6 @@ namespace Google.Common.Geometry.DataStructures
                 return false;
 
             return this.Item.Equals(no.Item);
-        }
-
-        public override int GetHashCode()
-        {
-            if (this.isnull)
-                return 0;
-
-            var result = Item.GetHashCode();
-
-            if (result >= 0)
-                result++;
-
-            return result;
         }
     }
 }

--- a/S2Geometry/DataStructures/NullObject.cs
+++ b/S2Geometry/DataStructures/NullObject.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Google.Common.Geometry.DataStructures
+{
+    public struct NullObject<T>
+    {
+        [DefaultValue(true)]
+        private bool isnull;// default property initializers are not supported for structs
+
+        private NullObject(T item, bool isnull) : this()
+        {
+            this.isnull = isnull;
+            this.Item = item;
+        }
+
+        public NullObject(T item) : this(item, item == null)
+        {
+        }
+
+        public static NullObject<T> Null()
+        {
+            return new NullObject<T>();
+        }
+
+        public T Item { get; private set; }
+
+        public bool IsNull()
+        {
+            return this.isnull;
+        }
+
+        public static implicit operator T(NullObject<T> nullObject)
+        {
+            return nullObject.Item;
+        }
+
+        public static implicit operator NullObject<T>(T item)
+        {
+            return new NullObject<T>(item);
+        }
+
+        public override string ToString()
+        {
+            return (Item != null) ? Item.ToString() : "NULL";
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+                return this.IsNull();
+
+            if (!(obj is NullObject<T>))
+                return false;
+
+            var no = (NullObject<T>)obj;
+
+            if (this.IsNull())
+                return no.IsNull();
+
+            if (no.IsNull())
+                return false;
+
+            return this.Item.Equals(no.Item);
+        }
+
+        public override int GetHashCode()
+        {
+            if (this.isnull)
+                return 0;
+
+            var result = Item.GetHashCode();
+
+            if (result >= 0)
+                result++;
+
+            return result;
+        }
+    }
+}

--- a/S2Geometry/DataStructures/NullObject.cs
+++ b/S2Geometry/DataStructures/NullObject.cs
@@ -8,9 +8,9 @@ namespace Google.Common.Geometry
         [DefaultValue(false)]
         private bool isNotNull;// default property initializers are not supported for structs
 
-        private NullObject(T item, bool isnull) : this()
+        private NullObject(T item, bool isNull) : this()
         {
-            this.isNotNull = isNotNull;
+            this.isNotNull = !isNull;
             this.Item = item;
         }
 

--- a/S2Geometry/DataStructures/NullObject.cs
+++ b/S2Geometry/DataStructures/NullObject.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Google.Common.Geometry
 {

--- a/S2Geometry/S2Geometry.csproj
+++ b/S2Geometry/S2Geometry.csproj
@@ -39,6 +39,7 @@
     <!-- A reference to the entire .NET Framework is automatically included -->
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DataStructures\NullObject.cs" />
     <Compile Include="DataStructures\PriorityQueue.cs" />
     <Compile Include="FpUtils.cs" />
     <Compile Include="IS2Region.cs" />
@@ -70,14 +71,6 @@
     <Compile Include="S2Polyline.cs" />
     <Compile Include="S2Projections.cs" />
     <Compile Include="S2RegionCoverer.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="C5">
-      <HintPath>..\packages\C5.2.2.5073.27396\lib\portable-net40+sl50+wp80+win\C5.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/S2Geometry/S2Polygon.cs
+++ b/S2Geometry/S2Polygon.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using Google.Common.Geometry.DataStructures;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using C5;
 
 namespace Google.Common.Geometry
 {
@@ -138,7 +138,7 @@ namespace Google.Common.Geometry
         {
             get
             {
-                var vertices = new HashBag<S2Point>();
+                var vertices = new HashSet<S2Point>();
 
 
                 S2Loop lastParent = null;
@@ -276,9 +276,8 @@ namespace Google.Common.Geometry
             // assert (this.loops.isEmpty());
 
             //Dictionary<S2Loop, List<S2Loop>> loopMap =new Dictionary<S2Loop, List<S2Loop>>();
-            // Note: We're using C5's HashDictionary because SCG's Dictionary<,> does not allow
-            // NULL keys
-            var loopMap = new HashDictionary<S2Loop, List<S2Loop>>();
+            // Note: We use a special NullObject to supply null keys.
+            var loopMap = new Dictionary<NullObject<S2Loop>, List<S2Loop>>();
             // Yes, a null key is valid. It is used here to refer to the root of the
             // loopMap
             loopMap[null] = new List<S2Loop>();
@@ -964,7 +963,7 @@ namespace Google.Common.Geometry
         }
 
         // For each map entry, sorts the value list.
-        private static void SortValueLoops(C5.IDictionary<S2Loop, List<S2Loop>> loopMap)
+        private static void SortValueLoops(IDictionary<NullObject<S2Loop>, List<S2Loop>> loopMap)
         {
             foreach (var key in loopMap.Keys)
             {
@@ -972,10 +971,10 @@ namespace Google.Common.Geometry
             }
         }
 
-        private static void InsertLoop(S2Loop newLoop, S2Loop parent, C5.IDictionary<S2Loop, List<S2Loop>> loopMap)
+        private static void InsertLoop(S2Loop newLoop, S2Loop parent, Dictionary<NullObject<S2Loop>, List<S2Loop>> loopMap)
         {
             List<S2Loop> children = null;
-            if (loopMap.Contains(parent))
+            if (loopMap.ContainsKey(parent))
                 children = loopMap[parent];
 
             if (children == null)
@@ -1000,7 +999,7 @@ namespace Google.Common.Geometry
             // Some of the children of the parent loop may now be children of
             // the new loop.
             List<S2Loop> newChildren = null;
-            if (loopMap.Contains(newLoop))
+            if (loopMap.ContainsKey(newLoop))
                 newChildren = loopMap[newLoop];
             for (var i = 0; i < children.Count;)
             {
@@ -1023,7 +1022,7 @@ namespace Google.Common.Geometry
             children.Add(newLoop);
         }
 
-        private void InitLoop(S2Loop loop, int depth, C5.IDictionary<S2Loop, List<S2Loop>> loopMap)
+        private void InitLoop(S2Loop loop, int depth, IDictionary<NullObject<S2Loop>, List<S2Loop>> loopMap)
         {
             if (loop != null)
             {
@@ -1031,7 +1030,7 @@ namespace Google.Common.Geometry
                 _loops.Add(loop);
             }
             List<S2Loop> children = null;
-            if (loopMap.Contains(loop))
+            if (loopMap.ContainsKey(loop))
                 children = loopMap[loop];
             if (children != null)
             {

--- a/S2Geometry/S2Polygon.cs
+++ b/S2Geometry/S2Polygon.cs
@@ -1,10 +1,8 @@
-﻿using Google.Common.Geometry.DataStructures;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Google.Common.Geometry
 {

--- a/S2Geometry/S2PolygonBuilder.cs
+++ b/S2Geometry/S2PolygonBuilder.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using C5;
 
 namespace Google.Common.Geometry
 {
@@ -42,7 +41,7 @@ namespace Google.Common.Geometry
    * The current set of edges, grouped by origin. The set of destination
    * vertices is a multiset so that the same edge can be present more than once.
    */
-        private readonly System.Collections.Generic.IDictionary<S2Point, HashBag<S2Point>> _edges;
+        private readonly System.Collections.Generic.IDictionary<S2Point, HashSet<S2Point>> _edges;
         private readonly S2PolygonBuilderOptions _options;
 
         /**
@@ -57,7 +56,7 @@ namespace Google.Common.Geometry
         public S2PolygonBuilder(S2PolygonBuilderOptions options)
         {
             _options = options;
-            _edges = new Dictionary<S2Point, HashBag<S2Point>>();
+            _edges = new Dictionary<S2Point, HashSet<S2Point>>();
         }
 
         public S2PolygonBuilderOptions Options
@@ -84,7 +83,7 @@ namespace Google.Common.Geometry
 
             if (_options.XorEdges)
             {
-                HashBag<S2Point> candidates;
+                HashSet<S2Point> candidates;
                 _edges.TryGetValue(v1, out candidates);
                 if (candidates != null && candidates.Any(c => c.Equals(v0)))
                 {
@@ -95,7 +94,7 @@ namespace Google.Common.Geometry
 
             if (!_edges.ContainsKey(v0))
             {
-                _edges[v0] = new HashBag<S2Point>();
+                _edges[v0] = new HashSet<S2Point>();
             }
 
             _edges[v0].Add(v1);
@@ -103,7 +102,7 @@ namespace Google.Common.Geometry
             {
                 if (!_edges.ContainsKey(v1))
                 {
-                    _edges[v1] = new HashBag<S2Point>();
+                    _edges[v1] = new HashSet<S2Point>();
                 }
                 _edges[v1].Add(v0);
             }
@@ -296,7 +295,7 @@ namespace Google.Common.Geometry
             var vset = _edges[v0];
             // assert (vset.count(v1) > 0);
             vset.Remove(v1);
-            if (vset.IsEmpty)
+            if (!vset.Any())
             {
                 _edges.Remove(v0);
             }
@@ -306,7 +305,7 @@ namespace Google.Common.Geometry
                 vset = _edges[v1];
                 // assert (vset.count(v0) > 0);
                 vset.Remove(v0);
-                if (vset.IsEmpty)
+                if (!vset.Any())
                 {
                     _edges.Remove(v1);
                 }
@@ -356,7 +355,7 @@ namespace Google.Common.Geometry
 
                 var v2 = default (S2Point);
                 var v2Found = false;
-                HashBag<S2Point> vset;
+                HashSet<S2Point> vset;
                 _edges.TryGetValue(v1, out vset);
                 if (vset != null)
                 {

--- a/S2Geometry/S2Polyline.cs
+++ b/S2Geometry/S2Polyline.cs
@@ -2,21 +2,19 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Google.Common.Geometry
 {
-/**
- * An S2Polyline represents a sequence of zero or more vertices connected by
- * straight edges (geodesics). Edges of length 0 and 180 degrees are not
- * allowed, i.e. adjacent vertices should not be identical or antipodal.
- *
- * <p>Note: Polylines do not have a Contains(S2Point) method, because
- * "containment" is not numerically well-defined except at the polyline
- * vertices.
- *
- */
+    /**
+     * An S2Polyline represents a sequence of zero or more vertices connected by
+     * straight edges (geodesics). Edges of length 0 and 180 degrees are not
+     * allowed, i.e. adjacent vertices should not be identical or antipodal.
+     *
+     * <p>Note: Polylines do not have a Contains(S2Point) method, because
+     * "containment" is not numerically well-defined except at the polyline
+     * vertices.
+     *
+     */
 
     public struct S2Polyline : IS2Region, IEquatable<S2Polyline>
     {

--- a/S2Geometry/S2Projections.cs
+++ b/S2Geometry/S2Projections.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Google.Common.Geometry
 {

--- a/S2Geometry/packages.config
+++ b/S2Geometry/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="C5" version="2.2.5073.27396" targetFramework="portable-net45+wp80+win+MonoAndroid10+MonoTouch10" />
-</packages>


### PR DESCRIPTION
Solves #2 and #1. Added a NullObject<> class to handle the null keys in Dictionary.